### PR TITLE
GH-33: Redesign show/create/edit pages

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -51,9 +51,15 @@ class PageController extends Controller
         $parentId = $request->get('parent_id');
         $parent = $parentId ? Page::findOrFail($parentId) : null;
 
+        $potentialParents = $mod->pages()
+            ->where('id', '!=', $parent?->id)
+            ->orderBy('title')
+            ->get();
+
         return Inertia::render('Pages/Create', [
             'mod' => $mod,
             'parent' => $parent,
+            'potentialParents' => $potentialParents,
         ]);
     }
 
@@ -135,9 +141,8 @@ class PageController extends Controller
 
         $navigation = $mod->pages()
             ->whereNull('parent_id')
-            ->where('published', true)
             ->with(['children' => function ($query) {
-                $query->where('published', true)->orderBy('order_index');
+                $query->orderBy('order_index');
             }])
             ->orderBy('order_index')
             ->get()
@@ -146,11 +151,13 @@ class PageController extends Controller
                     'id' => $navPage->id,
                     'title' => $navPage->title,
                     'slug' => $navPage->slug,
+                    'published' => $navPage->published,
                     'children' => $navPage->children->map(function ($child) {
                         return [
                             'id' => $child->id,
                             'title' => $child->title,
                             'slug' => $child->slug,
+                            'published' => $child->published,
                         ];
                     })->toArray(),
                 ];

--- a/resources/js/components/MarkdownRenderer.tsx
+++ b/resources/js/components/MarkdownRenderer.tsx
@@ -12,22 +12,18 @@ interface MarkdownRendererProps {
 
 const renderer = new marked.Renderer();
 
-renderer.code = function({ text, lang }: { text: string; lang?: string }) {
+renderer.code = function ({ text, lang }: { text: string; lang?: string }) {
   const language = lang && hljs.getLanguage(lang) ? lang : 'plaintext';
   const highlighted = hljs.highlight(text, { language }).value;
 
   return `<pre class="hljs-code-block"><code class="hljs language-${language}">${highlighted}</code></pre>`;
 };
 
-renderer.codespan = function({ text }: { text: string }) {
+renderer.codespan = function ({ text }: { text: string }) {
   return `<code class="inline-code">${text}</code>`;
 };
 
-marked.use(
-  gfmHeadingId(),
-  markedFootnote(),
-  { renderer }
-);
+marked.use(gfmHeadingId(), markedFootnote(), { renderer });
 
 marked.setOptions({
   gfm: true,

--- a/resources/js/components/app-footer.tsx
+++ b/resources/js/components/app-footer.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@inertiajs/react';
-import { Github, ExternalLink, HeartHandshake } from 'lucide-react';
+import { ExternalLink } from 'lucide-react';
 import HytaleModdingLogo from './hytale-modding-logo';
 
 export default function AppFooter() {

--- a/resources/js/components/markdown-editor-preview.tsx
+++ b/resources/js/components/markdown-editor-preview.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import MarkdownRenderer from '@/components/MarkdownRenderer';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+
+interface MarkdownEditorPreviewProps {
+  content: string;
+  onContentChange: (content: string) => void;
+  lineCount: number;
+  error?: string;
+}
+
+// Constants
+const EDITOR_MIN_HEIGHT = 'calc(100vh - 280px)';
+const CARD_CLASSES =
+  'border-border/40 bg-card/50 overflow-hidden flex flex-col';
+const CARD_HEADER_CLASSES =
+  'border-b border-border/40 bg-muted/30 px-4 py-3 shrink-0';
+const CARD_TITLE_CLASSES = 'text-sm font-semibold text-muted-foreground';
+const TOGGLE_BUTTON_CLASSES = 'h-7 text-xs';
+
+export default function MarkdownEditorPreview({
+  content,
+  onContentChange,
+  lineCount,
+  error,
+}: MarkdownEditorPreviewProps) {
+  const [showPreview, setShowPreview] = useState(false);
+  const [showEditor, setShowEditor] = useState(true);
+
+  const isInSplitView = showEditor && showPreview;
+
+  return (
+    <div
+      className={`grid gap-4 ${isInSplitView ? 'lg:grid-cols-2' : 'grid-cols-1'}`}
+    >
+      {/*  Markdown Editor  */}
+      {showEditor && (
+        <Card className={CARD_CLASSES} style={{ minHeight: EDITOR_MIN_HEIGHT }}>
+          <CardHeader className={CARD_HEADER_CLASSES}>
+            <div className="flex items-center justify-between">
+              <CardTitle className={CARD_TITLE_CLASSES}>
+                Content Editor
+              </CardTitle>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setShowEditor(false);
+                    setShowPreview(true);
+                  }}
+                  className={TOGGLE_BUTTON_CLASSES}
+                >
+                  Hide Editor
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setShowPreview((prev) => !prev)}
+                  className={TOGGLE_BUTTON_CLASSES}
+                >
+                  {showPreview ? 'Hide Preview' : 'Show Preview'}
+                </Button>
+              </div>
+            </div>
+          </CardHeader>
+
+          <CardContent className="flex flex-1 flex-col overflow-hidden p-0">
+            {/* Editor with Line Numbers */}
+            <div className="relative flex flex-1 overflow-hidden">
+              {/* Line Numbers Gutter */}
+              <div className="w-12 shrink-0 overflow-y-auto border-r border-border/40 bg-muted/30">
+                <div className="flex flex-col items-center pt-3 font-mono text-xs text-muted-foreground select-none">
+                  {Array.from({ length: lineCount }, (_, i) => (
+                    <div key={i + 1} className="h-6 leading-6">
+                      {i + 1}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Markdown Textarea */}
+              <Textarea
+                id="content"
+                value={content}
+                rows={lineCount}
+                onChange={(e) => onContentChange(e.target.value)}
+                placeholder="# Welcome
+
+Write your content here using Markdown syntax.
+
+## Features
+
+- Feature 1
+- Feature 2
+
+```bash
+# Example code block
+echo 'Hello World'
+```"
+                className={`flex-1 resize-none overflow-y-auto rounded-none border-0 bg-background/50 px-4 py-3 font-mono text-sm leading-6 focus-visible:ring-0 focus-visible:ring-offset-0 ${error ? 'min-h-screen border-l-2 border-l-destructive' : ''} `}
+              />
+            </div>
+
+            {/* Editor Footer */}
+            <div className="flex shrink-0 items-center justify-between border-t border-border/40 bg-muted/20 px-4 py-2 text-xs text-muted-foreground">
+              <div className="flex items-center gap-4">
+                {error ? (
+                  <span className="font-medium text-destructive">{error}</span>
+                ) : (
+                  <span>Markdown • {content.length} characters</span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <span>UTF-8</span>
+                <span>•</span>
+                <span>Ln {lineCount}</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/*  Live Preview  */}
+      {showPreview && (
+        <Card className={CARD_CLASSES} style={{ minHeight: EDITOR_MIN_HEIGHT }}>
+          <CardHeader className={CARD_HEADER_CLASSES}>
+            <div className="flex items-center justify-between">
+              <CardTitle className={CARD_TITLE_CLASSES}>Live Preview</CardTitle>
+              {!showEditor && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setShowEditor(true)}
+                  className={TOGGLE_BUTTON_CLASSES}
+                >
+                  Show Editor
+                </Button>
+              )}
+            </div>
+          </CardHeader>
+
+          <CardContent className="flex-1 overflow-hidden p-0">
+            <div className="h-full overflow-y-auto bg-background/50 p-6">
+              <MarkdownRenderer
+                content={content || 'Nothing to preview yet...'}
+              />
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/resources/js/components/mod-navbar.tsx
+++ b/resources/js/components/mod-navbar.tsx
@@ -1,5 +1,11 @@
 import { Link, usePage } from '@inertiajs/react';
-import { Menu, Settings, Github, ExternalLink, BookOpenIcon } from 'lucide-react';
+import {
+  Menu,
+  Settings,
+  Github,
+  ExternalLink,
+  BookOpenIcon,
+} from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
@@ -44,7 +50,11 @@ function ModIcon({ size = 'h-8 w-8', modName, modIconUrl }: ModIconProps) {
   return <BookOpenIcon className={cn(size, 'text-primary')} />;
 }
 
-export default function ModNavbar({ modName, modSlug, modIconUrl }: ModNavbarProps) {
+export default function ModNavbar({
+  modName,
+  modSlug,
+  modIconUrl,
+}: ModNavbarProps) {
   const { isCurrentUrl } = useCurrentUrl();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const { auth } = usePage<SharedData>().props;
@@ -108,7 +118,11 @@ export default function ModNavbar({ modName, modSlug, modIconUrl }: ModNavbarPro
               <SheetHeader>
                 <SheetTitle className="text-left">
                   <div className="flex items-center space-x-3">
-                    <ModIcon size="h-8 w-8" modName={modName} modIconUrl={modIconUrl} />
+                    <ModIcon
+                      size="h-8 w-8"
+                      modName={modName}
+                      modIconUrl={modIconUrl}
+                    />
                     <span className="bg-clip-text text-lg font-bold text-black dark:text-white">
                       {modName}
                     </span>

--- a/resources/js/layouts/public-layout.tsx
+++ b/resources/js/layouts/public-layout.tsx
@@ -33,7 +33,11 @@ export default function PublicLayout({
   return (
     <div className="flex min-h-screen flex-col bg-background">
       {modName && modSlug ? (
-        <ModNavbar modName={modName} modSlug={modSlug} modIconUrl={modIconUrl} />
+        <ModNavbar
+          modName={modName}
+          modSlug={modSlug}
+          modIconUrl={modIconUrl}
+        />
       ) : (
         <AppNavbar />
       )}

--- a/resources/js/pages/Pages/Create.tsx
+++ b/resources/js/pages/Pages/Create.tsx
@@ -1,10 +1,19 @@
 import { Head, useForm } from '@inertiajs/react';
+import { ChevronRightIcon } from 'lucide-react';
+import { useMemo, useCallback } from 'react';
+import MarkdownEditorPreview from '@/components/markdown-editor-preview';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import AppLayout from '@/layouts/app-layout';
 
 interface Mod {
@@ -22,9 +31,18 @@ interface Page {
 interface Props {
   mod: Mod;
   parent?: Page;
+  potentialParents?: Page[];
 }
 
-export default function CreatePage({ mod, parent }: Props) {
+// Constants
+const MIN_EDITOR_LINES = 30;
+
+export default function CreatePage({
+  mod,
+  parent,
+  potentialParents = [],
+}: Props) {
+  // Form state management
   const { data, setData, post, processing, errors } = useForm({
     title: '',
     content: '',
@@ -33,60 +51,112 @@ export default function CreatePage({ mod, parent }: Props) {
     published: true,
   });
 
-  const submit = (e: React.SubmitEvent) => {
-    e.preventDefault();
+  // Memoized values
+  const lineCount = useMemo(
+    () => Math.max(data.content.split('\n').length, MIN_EDITOR_LINES),
+    [data.content],
+  );
+
+  const modUrl = `/dashboard/mods/${mod.slug}`;
+
+  const handleSubmit = useCallback(
+    (e: React.SubmitEvent) => {
+      e.preventDefault();
+      post(`/dashboard/mods/${mod.slug}/pages`);
+    },
+    [post, mod.slug],
+  );
+
+  const handleSaveAsDraft = useCallback(() => {
+    setData('published', false);
     post(`/dashboard/mods/${mod.slug}/pages`);
-  };
+  }, [post, mod.slug, setData]);
 
   return (
     <AppLayout>
       <Head title={`Create Page - ${mod.name}`} />
 
-      <div className="mx-auto max-w-4xl px-4 py-6 sm:px-6 lg:px-8">
-        <div className="mb-8">
-          <nav className="mb-4 text-sm text-gray-600">
-            <a
-              href={`/dashboard/mods/${mod.slug}`}
-              className="hover:text-gray-800"
-            >
+      <div className="mx-auto max-w-full px-4 py-6 sm:px-6 lg:px-8">
+        {/*  Page Header  */}
+        <header className="mb-8">
+          {/* Breadcrumb Navigation */}
+          <nav className="mb-4 flex items-center text-sm text-primary">
+            <a href={modUrl} className="hover:underline">
               {mod.name}
             </a>
             {parent && (
               <>
-                <span className="mx-2">›</span>
+                <ChevronRightIcon className="mx-2 h-4 w-4" />
                 <span>{parent.title}</span>
               </>
             )}
-            <span className="mx-2">›</span>
+            <ChevronRightIcon className="mx-2 h-4 w-4" />
             <span>New Page</span>
           </nav>
-          <h1 className="text-3xl font-bold text-gray-900">Create New Page</h1>
-          <p className="mt-2 text-gray-600">
+
+          <h1 className="text-3xl font-bold text-primary">Create New Page</h1>
+          <p className="mt-2 text-muted-foreground">
             Add a new documentation page to your mod
           </p>
-        </div>
+        </header>
 
-        <form onSubmit={submit} className="space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Page Details</CardTitle>
+        {/*  Create Form  */}
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/*  Page Details Card  */}
+          <Card className="border-border/40 bg-card/50">
+            <CardHeader className="border-b border-border/40 bg-muted/20 px-6 py-4">
+              <CardTitle className="text-base font-semibold">
+                Page Details
+              </CardTitle>
             </CardHeader>
-            <CardContent className="space-y-6">
-              <div>
-                <Label htmlFor="title">Page Title *</Label>
-                <Input
-                  id="title"
-                  type="text"
-                  value={data.title}
-                  onChange={(e) => setData('title', e.target.value)}
-                  placeholder="Getting Started"
-                  className={errors.title ? 'border-red-500' : ''}
-                />
-                {errors.title && (
-                  <p className="mt-1 text-sm text-red-600">{errors.title}</p>
-                )}
+            <CardContent className="space-y-6 px-6 py-5">
+              {/* Title and Parent Fields */}
+              <div className="grid gap-6 md:grid-cols-2">
+                {/* Title Input */}
+                <div>
+                  <Label htmlFor="title">Page Title *</Label>
+                  <Input
+                    id="title"
+                    type="text"
+                    value={data.title}
+                    onChange={(e) => setData('title', e.target.value)}
+                    placeholder="Getting Started"
+                    className={errors.title ? 'border-destructive' : ''}
+                  />
+                  {errors.title && (
+                    <p className="mt-1 text-sm text-destructive">
+                      {errors.title}
+                    </p>
+                  )}
+                </div>
+
+                {/* Parent Page Select */}
+                <div>
+                  <Label htmlFor="parent_id">Parent Page</Label>
+                  <Select
+                    value={data.parent_id || 'none'}
+                    onValueChange={(value) =>
+                      setData('parent_id', value === 'none' ? '' : value)
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="No parent (root page)" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">
+                        No parent (root page)
+                      </SelectItem>
+                      {potentialParents.map((parent) => (
+                        <SelectItem key={parent.id} value={parent.id}>
+                          {parent.title}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
               </div>
 
+              {/* Page Options Checkboxes */}
               <div className="flex items-center space-x-6">
                 <div className="flex items-center space-x-2">
                   <Checkbox
@@ -100,65 +170,45 @@ export default function CreatePage({ mod, parent }: Props) {
                     Index page (home page of the mod)
                   </Label>
                 </div>
+
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="published"
+                    checked={data.published}
+                    onCheckedChange={(checked) =>
+                      setData('published', !!checked)
+                    }
+                  />
+                  <Label htmlFor="published" className="text-sm">
+                    Published
+                  </Label>
+                </div>
               </div>
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Content</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div>
-                <Label htmlFor="content">Page Content (Markdown)</Label>
-                <Textarea
-                  id="content"
-                  value={data.content}
-                  onChange={(e) => setData('content', e.target.value)}
-                  placeholder="# Welcome to my mod
+          {/* Content Editor & Preview Section */}
+          {/* Content Editor & Preview Section */}
+          <MarkdownEditorPreview
+            content={data.content}
+            onContentChange={(content) => setData('content', content)}
+            lineCount={lineCount}
+            error={errors.content}
+          />
 
-This is the main page of my mod documentation.
-
-## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# Install the mod
-./install.sh
-```
-
-For more information, see the other pages in this documentation."
-                  rows={20}
-                  className={`font-mono text-sm ${errors.content ? 'border-red-500' : ''}`}
-                />
-                {errors.content && (
-                  <p className="mt-1 text-sm text-red-600">{errors.content}</p>
-                )}
-                <p className="mt-2 text-sm text-gray-600">
-                  Use Markdown syntax to format your content. You can include
-                  code blocks, images, links, and more.
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-
+          {/*  Form Actions  */}
           <div className="flex items-center justify-between pt-4">
+            {/* Cancel Action */}
             <Button type="button" variant="outline" asChild>
-              <a href={`/dashboard/mods/${mod.slug}`}>Cancel</a>
+              <a href={modUrl}>Cancel</a>
             </Button>
+
+            {/* Save Actions */}
             <div className="flex space-x-3">
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => {
-                  setData('published', false);
-                  post(`/dashboard/mods/${mod.slug}/pages`);
-                }}
+                onClick={handleSaveAsDraft}
                 disabled={processing}
               >
                 {processing ? 'Saving...' : 'Save as Draft'}

--- a/resources/js/pages/Pages/Edit.tsx
+++ b/resources/js/pages/Pages/Edit.tsx
@@ -1,5 +1,6 @@
 import { Head, useForm, router } from '@inertiajs/react';
-import { useState } from 'react';
+import { ChevronRightIcon } from 'lucide-react';
+import { useState, useMemo, useCallback } from 'react';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -15,6 +16,10 @@ import {
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import AppLayout from '@/layouts/app-layout';
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
 
 interface Mod {
   id: string;
@@ -44,7 +49,19 @@ interface Props {
   potentialParents: PotentialParent[];
 }
 
+const MIN_EDITOR_LINES = 30;
+const EDITOR_MIN_HEIGHT = 'calc(100vh - 280px)';
+
+// Reusable Tailwind class patterns
+const CARD_CLASSES =
+  'border-border/40 bg-card/50 overflow-hidden flex flex-col';
+const CARD_HEADER_CLASSES =
+  'border-b border-border/40 bg-muted/30 px-4 py-3 flex-shrink-0';
+const CARD_TITLE_CLASSES = 'text-sm font-semibold text-muted-foreground';
+const TOGGLE_BUTTON_CLASSES = 'h-7 text-xs';
+
 export default function EditPage({ mod, page, potentialParents }: Props) {
+  // Form state management
   const { data, setData, patch, processing, errors } = useForm({
     title: page.title,
     content: page.content,
@@ -53,49 +70,84 @@ export default function EditPage({ mod, page, potentialParents }: Props) {
     published: page.published,
   });
 
+  // View state management
   const [showPreview, setShowPreview] = useState(false);
+  const [showEditor, setShowEditor] = useState(true);
 
-  const submit = (e: React.FormEvent) => {
-    e.preventDefault();
-    patch(`/dashboard/mods/${mod.slug}/pages/${page.slug}`);
-  };
+  // Memoized values
+  const lineCount = useMemo(
+    () => Math.max(data.content.split('\n').length, MIN_EDITOR_LINES),
+    [data.content],
+  );
+
+  const isInSplitView = showEditor && showPreview;
+  const pageUrl = `/dashboard/mods/${mod.slug}/pages/${page.slug}`;
+  const modUrl = `/dashboard/mods/${mod.slug}`;
+
+  const handleSubmit = useCallback(
+    (e: React.SubmitEvent) => {
+      e.preventDefault();
+      patch(pageUrl);
+    },
+    [patch, pageUrl],
+  );
+
+  const handleDelete = useCallback(() => {
+    if (
+      confirm(
+        'Are you sure you want to delete this page? This action cannot be undone.',
+      )
+    ) {
+      router.delete(pageUrl);
+    }
+  }, [pageUrl]);
+
+  const handleSaveAsDraft = useCallback(() => {
+    router.patch(pageUrl, { ...data, published: false });
+  }, [pageUrl, data]);
+
+  const togglePreview = () => setShowPreview((prev) => !prev);
+  const toggleEditor = () => setShowEditor((prev) => !prev);
 
   return (
     <AppLayout>
       <Head title={`Edit ${page.title} - ${mod.name}`} />
 
-      <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
-        <div className="mb-8">
-          <nav className="mb-4 text-sm text-gray-600">
-            <a
-              href={`/dashboard/mods/${mod.slug}`}
-              className="hover:text-gray-800"
-            >
+      <div className="mx-auto max-w-full px-4 py-6 sm:px-6 lg:px-8">
+        {/* ========== Page Header ========== */}
+        <header className="mb-8">
+          {/* Breadcrumb Navigation */}
+          <nav className="mb-4 flex items-center text-sm text-primary">
+            <a href={modUrl} className="hover:underline">
               {mod.name}
             </a>
-            <span className="mx-2">›</span>
-            <a
-              href={`/dashboard/mods/${mod.slug}/pages/${page.slug}`}
-              className="hover:text-gray-800"
-            >
+            <ChevronRightIcon className="mx-2 h-4 w-4" />
+            <a href={pageUrl} className="hover:underline">
               {page.title}
             </a>
-            <span className="mx-2">›</span>
+            <ChevronRightIcon className="mx-2 h-4 w-4" />
             <span>Edit</span>
           </nav>
-          <h1 className="text-3xl font-bold text-gray-900">Edit Page</h1>
-          <p className="mt-2 text-gray-600">
+
+          <h1 className="text-3xl font-bold text-primary">Edit Page</h1>
+          <p className="mt-2 text-muted-foreground">
             Update your documentation page content and settings
           </p>
-        </div>
+        </header>
 
-        <form onSubmit={submit} className="space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Page Details</CardTitle>
+        {/* ========== Edit Form ========== */}
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* ========== Page Details Card ========== */}
+          <Card className="border-border/40 bg-card/50">
+            <CardHeader className="border-b border-border/40 bg-muted/20 px-6 py-4">
+              <CardTitle className="text-base font-semibold">
+                Page Details
+              </CardTitle>
             </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <CardContent className="space-y-6 px-6 py-5">
+              {/* Title and Parent Fields */}
+              <div className="grid gap-6 md:grid-cols-2">
+                {/* Title Input */}
                 <div>
                   <Label htmlFor="title">Page Title *</Label>
                   <Input
@@ -104,13 +156,16 @@ export default function EditPage({ mod, page, potentialParents }: Props) {
                     value={data.title}
                     onChange={(e) => setData('title', e.target.value)}
                     placeholder="Getting Started"
-                    className={errors.title ? 'border-red-500' : ''}
+                    className={errors.title ? 'border-destructive' : ''}
                   />
                   {errors.title && (
-                    <p className="mt-1 text-sm text-red-600">{errors.title}</p>
+                    <p className="mt-1 text-sm text-destructive">
+                      {errors.title}
+                    </p>
                   )}
                 </div>
 
+                {/* Parent Page Select */}
                 <div>
                   <Label htmlFor="parent_id">Parent Page</Label>
                   <Select
@@ -136,6 +191,7 @@ export default function EditPage({ mod, page, potentialParents }: Props) {
                 </div>
               </div>
 
+              {/* Page Options Checkboxes */}
               <div className="flex items-center space-x-6">
                 <div className="flex items-center space-x-2">
                   <Checkbox
@@ -166,30 +222,68 @@ export default function EditPage({ mod, page, potentialParents }: Props) {
             </CardContent>
           </Card>
 
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-            {/* Editor */}
-            <Card>
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  <CardTitle>Content Editor</CardTitle>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setShowPreview(!showPreview)}
-                  >
-                    {showPreview ? 'Hide Preview' : 'Show Preview'}
-                  </Button>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <div>
-                  <Label htmlFor="content">Page Content (Markdown)</Label>
-                  <Textarea
-                    id="content"
-                    value={data.content}
-                    onChange={(e) => setData('content', e.target.value)}
-                    placeholder="# Welcome
+          {/* Content Editor & Preview Section */}
+          <div
+            className={`grid gap-4 ${isInSplitView ? 'lg:grid-cols-2' : 'grid-cols-1'}`}
+          >
+            {/* Markdown Editor */}
+            {showEditor && (
+              <Card
+                className={CARD_CLASSES}
+                style={{ minHeight: EDITOR_MIN_HEIGHT }}
+              >
+                <CardHeader className={CARD_HEADER_CLASSES}>
+                  <div className="flex items-center justify-between">
+                    <CardTitle className={CARD_TITLE_CLASSES}>
+                      Content Editor
+                    </CardTitle>
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setShowEditor(false);
+                          setShowPreview(true);
+                        }}
+                        className={TOGGLE_BUTTON_CLASSES}
+                      >
+                        Hide Editor
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={togglePreview}
+                        className={TOGGLE_BUTTON_CLASSES}
+                      >
+                        {showPreview ? 'Hide Preview' : 'Show Preview'}
+                      </Button>
+                    </div>
+                  </div>
+                </CardHeader>
+
+                <CardContent className="flex flex-1 flex-col overflow-hidden p-0">
+                  {/* Editor with Line Numbers */}
+                  <div className="relative flex flex-1 overflow-hidden">
+                    {/* Line Numbers Gutter */}
+                    <div className="w-12 shrink-0 overflow-y-auto border-r border-border/40 bg-muted/30">
+                      <div className="flex flex-col items-center pt-3 font-mono text-xs text-muted-foreground select-none">
+                        {Array.from({ length: lineCount }, (_, i) => (
+                          <div key={i + 1} className="h-6 leading-6">
+                            {i + 1}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    {/* Markdown Textarea */}
+                    <Textarea
+                      id="content"
+                      value={data.content}
+                      rows={lineCount}
+                      onChange={(e) => setData('content', e.target.value)}
+                      placeholder="# Welcome
 
 Write your content here using Markdown syntax.
 
@@ -202,30 +296,58 @@ Write your content here using Markdown syntax.
 # Example code block
 echo 'Hello World'
 ```"
-                    rows={20}
-                    className={`font-mono text-sm ${errors.content ? 'border-red-500' : ''}`}
-                  />
-                  {errors.content && (
-                    <p className="mt-1 text-sm text-red-600">
-                      {errors.content}
-                    </p>
-                  )}
-                  <p className="mt-2 text-sm text-gray-600">
-                    Use Markdown syntax to format your content. Supports
-                    headers, lists, code blocks, links, and more.
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
+                      className={`flex-1 resize-none overflow-y-auto rounded-none border-0 bg-background/50 px-4 py-3 font-mono text-sm leading-6 focus-visible:ring-0 focus-visible:ring-offset-0 ${errors.content ? 'min-h-screen border-l-2 border-l-destructive' : ''} `}
+                    />
+                  </div>
 
-            {/* Preview */}
+                  {/* Editor Footer */}
+                  <div className="flex shrink-0 items-center justify-between border-t border-border/40 bg-muted/20 px-4 py-2 text-xs text-muted-foreground">
+                    <div className="flex items-center gap-4">
+                      {errors.content ? (
+                        <span className="font-medium text-destructive">
+                          {errors.content}
+                        </span>
+                      ) : (
+                        <span>Markdown • {data.content.length} characters</span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span>UTF-8</span>
+                      <span>•</span>
+                      <span>Ln {lineCount}</span>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Live Preview */}
             {showPreview && (
-              <Card>
-                <CardHeader>
-                  <CardTitle>Live Preview</CardTitle>
+              <Card
+                className={CARD_CLASSES}
+                style={{ minHeight: EDITOR_MIN_HEIGHT }}
+              >
+                <CardHeader className={CARD_HEADER_CLASSES}>
+                  <div className="flex items-center justify-between">
+                    <CardTitle className={CARD_TITLE_CLASSES}>
+                      Live Preview
+                    </CardTitle>
+                    {!showEditor && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={toggleEditor}
+                        className={TOGGLE_BUTTON_CLASSES}
+                      >
+                        Show Editor
+                      </Button>
+                    )}
+                  </div>
                 </CardHeader>
-                <CardContent>
-                  <div className="min-h-100 rounded-md border p-4">
+
+                <CardContent className="flex-1 overflow-hidden p-0">
+                  <div className="h-full overflow-y-auto bg-background/50 p-6">
                     <MarkdownRenderer
                       content={data.content || 'Nothing to preview yet...'}
                     />
@@ -235,44 +357,28 @@ echo 'Hello World'
             )}
           </div>
 
+          {/* Form Actions */}
           <div className="flex items-center justify-between pt-4">
+            {/* Destructive Actions */}
             <div className="flex space-x-3">
               <Button type="button" variant="outline" asChild>
-                <a href={`/dashboard/mods/${mod.slug}/pages/${page.slug}`}>
-                  Cancel
-                </a>
+                <a href={pageUrl}>Cancel</a>
               </Button>
               <Button
                 type="button"
                 variant="destructive"
-                onClick={() => {
-                  if (
-                    confirm(
-                      'Are you sure you want to delete this page? This action cannot be undone.',
-                    )
-                  ) {
-                    router.delete(
-                      `/dashboard/mods/${mod.slug}/pages/${page.slug}`,
-                    );
-                  }
-                }}
+                onClick={handleDelete}
               >
                 Delete Page
               </Button>
             </div>
+
+            {/* Save Actions */}
             <div className="flex space-x-3">
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => {
-                  router.patch(
-                    `/dashboard/mods/${mod.slug}/pages/${page.slug}`,
-                    {
-                      ...data,
-                      published: false,
-                    },
-                  );
-                }}
+                onClick={handleSaveAsDraft}
                 disabled={processing}
               >
                 {processing ? 'Saving...' : 'Save as Draft'}

--- a/resources/js/pages/Pages/Index.tsx
+++ b/resources/js/pages/Pages/Index.tsx
@@ -9,12 +9,14 @@ import {
   ArrowsUpDownIcon,
 } from '@heroicons/react/24/outline';
 import { Head, router } from '@inertiajs/react';
+import { ChevronRightIcon, HammerIcon } from 'lucide-react';
 import React, { useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import AppLayout from '@/layouts/app-layout';
+import { formatDate } from '@/utils/commonUtils';
 
 interface User {
   id: number;
@@ -55,14 +57,6 @@ export default function PagesIndex({ mod, pages, canEdit }: Props) {
   const [pagesList, setPagesList] = useState(pages);
   const [isDragDisabled, setIsDragDisabled] = useState(false);
   const [isDragModeEnabled, setIsDragModeEnabled] = useState(false);
-
-  const formatDate = (date: string) => {
-    return new Date(date).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
-  };
 
   const handleDragEnd = async (result: DropResult) => {
     if (!result.destination || !canEdit || !isDragModeEnabled) {
@@ -147,10 +141,8 @@ export default function PagesIndex({ mod, pages, canEdit }: Props) {
         <tr
           ref={provided.innerRef}
           {...provided.draggableProps}
-          className={`group border-b border-gray-100 transition-all hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-800/50 ${
-            snapshot.isDragging
-              ? 'bg-blue-50 shadow-lg dark:bg-blue-900/50'
-              : ''
+          className={`group border-b transition-all hover:bg-muted/50 ${
+            snapshot.isDragging ? 'bg-accent shadow-lg' : ''
           } ${isDragModeEnabled && canEdit ? 'hover:bg-orange-50 dark:hover:bg-orange-900/20' : ''}`}
         >
           {/* Hierarchy + Title Column */}
@@ -167,20 +159,16 @@ export default function PagesIndex({ mod, pages, canEdit }: Props) {
                     {ancestorLines.map((hasLine, i) => (
                       <div
                         key={i}
-                        className={`h-6 w-4 ${hasLine ? 'border-l border-gray-300 dark:border-gray-600' : ''}`}
+                        className={`h-6 w-4 ${hasLine ? 'border-l border-border' : ''}`}
                       />
                     ))}
                     {/* Current level connector */}
                     <div className="relative h-6 w-4">
                       <div
-                        className={`absolute top-0 left-0 h-3 w-3 border-b border-l border-gray-300 dark:border-gray-600 ${
-                          isLastAtLevel
-                            ? 'border-b-gray-300 dark:border-b-gray-600'
-                            : ''
-                        }`}
+                        className={`absolute top-0 left-0 h-3 w-3 border-b border-l border-border`}
                       />
                       {!isLastAtLevel && (
-                        <div className="absolute top-3 bottom-0 left-0 w-0 border-l border-gray-300 dark:border-gray-600" />
+                        <div className="absolute top-3 bottom-0 left-0 w-0 border-l border-border" />
                       )}
                     </div>
                   </div>
@@ -191,10 +179,10 @@ export default function PagesIndex({ mod, pages, canEdit }: Props) {
               {canEdit && isDragModeEnabled && (
                 <div
                   {...provided.dragHandleProps}
-                  className="mr-2 cursor-grab rounded p-1 opacity-60 group-hover:opacity-100 hover:bg-gray-200 active:cursor-grabbing dark:hover:bg-gray-700"
+                  className="mr-2 cursor-grab rounded p-1 opacity-60 group-hover:opacity-100 hover:bg-muted active:cursor-grabbing"
                   title="Drag to reorder"
                 >
-                  <Bars3Icon className="h-3 w-3 text-gray-500 dark:text-gray-400" />
+                  <Bars3Icon className="h-3 w-3 text-muted-foreground" />
                 </div>
               )}
 
@@ -210,17 +198,21 @@ export default function PagesIndex({ mod, pages, canEdit }: Props) {
               <div className="flex min-w-0 flex-1 items-center">
                 <a
                   href={`/dashboard/mods/${mod.slug}/pages/${page.slug}`}
-                  className="truncate font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                  className="truncate font-medium text-primary hover:underline"
                 >
                   {page.title}
                 </a>
                 {!page.published && (
-                  <Badge variant="outline" className="ml-2 text-xs">
+                  <Badge
+                    variant="outline"
+                    className="ml-2 border-yellow-400 text-xs text-yellow-400"
+                  >
+                    <HammerIcon className="mr-1 h-3 w-3" />
                     Draft
                   </Badge>
                 )}
                 {page.children && page.children.length > 0 && (
-                  <span className="ml-2 shrink-0 text-xs text-gray-500 dark:text-gray-400">
+                  <span className="ml-2 shrink-0 text-xs text-muted-foreground">
                     ({page.children.length})
                   </span>
                 )}
@@ -237,11 +229,11 @@ export default function PagesIndex({ mod, pages, canEdit }: Props) {
             />
           </td>
 
-          <td className="truncate px-2 py-2 text-sm text-gray-600 dark:text-gray-400">
+          <td className="truncate px-2 py-2 text-sm text-muted-foreground">
             {page.creator.name}
           </td>
 
-          <td className="px-2 py-2 text-sm text-gray-600 dark:text-gray-400">
+          <td className="px-2 py-2 text-sm text-muted-foreground">
             {formatDate(page.updated_at)}
           </td>
 
@@ -293,7 +285,7 @@ export default function PagesIndex({ mod, pages, canEdit }: Props) {
             ref={provided.innerRef}
             {...provided.droppableProps}
             className={`transition-colors ${
-              snapshot.isDraggingOver ? 'bg-blue-50 dark:bg-blue-900/30' : ''
+              snapshot.isDraggingOver ? 'bg-accent/50' : ''
             }`}
           >
             {sortedPages.map((page, index) => {
@@ -350,22 +342,17 @@ export default function PagesIndex({ mod, pages, canEdit }: Props) {
 
       <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
         <div className="mb-8">
-          <nav className="mb-4 text-sm text-gray-600 dark:text-gray-400">
-            <a
-              href={`/dashboard/mods/${mod.slug}`}
-              className="hover:text-gray-800 dark:hover:text-gray-200"
-            >
+          <nav className="mb-4 text-sm text-primary">
+            <a href={`/dashboard/mods/${mod.slug}`} className="hover:underline">
               {mod.name}
             </a>
-            <span className="mx-2">›</span>
+            <ChevronRightIcon className="m-1 inline h-4 w-4" />
             <span>All Pages</span>
           </nav>
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
-                All Pages
-              </h1>
-              <p className="mt-2 text-gray-600 dark:text-gray-400">
+              <h1 className="text-3xl font-bold text-primary">All Pages</h1>
+              <p className="mt-2 text-muted-foreground">
                 Browse all documentation pages in this mod
                 {isDragModeEnabled && ' - Drag and drop enabled'}
               </p>
@@ -422,11 +409,11 @@ export default function PagesIndex({ mod, pages, canEdit }: Props) {
         {pagesList.length === 0 ? (
           <Card>
             <CardContent className="py-12 text-center">
-              <BookOpenIcon className="mx-auto mb-4 h-12 w-12 text-gray-400 dark:text-gray-500" />
-              <h3 className="mb-2 text-lg font-medium text-gray-900 dark:text-gray-100">
+              <BookOpenIcon className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+              <h3 className="mb-2 text-lg font-medium text-primary">
                 No pages yet
               </h3>
-              <p className="mb-4 text-gray-600 dark:text-gray-400">
+              <p className="mb-4 text-muted-foreground">
                 Start documenting your mod by creating your first page
               </p>
               {canEdit && (
@@ -441,33 +428,33 @@ export default function PagesIndex({ mod, pages, canEdit }: Props) {
         ) : (
           <div className="space-y-4">
             <div className="mb-6 flex items-center justify-between">
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+              <h2 className="text-xl font-semibold text-primary">
                 {pagesList.length} Pages
               </h2>
-              <div className="flex items-center space-x-4 text-sm text-gray-600 dark:text-gray-400">
+              <div className="flex items-center space-x-4 text-sm text-muted-foreground">
                 <span>{rootPages.length} root pages</span>
                 <span>{childPages.length} subpages</span>
               </div>
             </div>
 
             <DragDropContext onDragEnd={handleDragEnd}>
-              <div className="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+              <div className="overflow-hidden rounded-lg border border-border bg-card">
                 <table className="min-w-full">
-                  <thead className="bg-gray-50 dark:bg-gray-800/50">
+                  <thead className="bg-muted/50">
                     <tr>
-                      <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                      <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-muted-foreground uppercase">
                         Page
                       </th>
-                      <th className="px-2 py-3 text-center text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                      <th className="px-2 py-3 text-center text-xs font-medium tracking-wider text-muted-foreground uppercase">
                         Status
                       </th>
-                      <th className="px-2 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                      <th className="px-2 py-3 text-left text-xs font-medium tracking-wider text-muted-foreground uppercase">
                         Author
                       </th>
-                      <th className="px-2 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                      <th className="px-2 py-3 text-left text-xs font-medium tracking-wider text-muted-foreground uppercase">
                         Updated
                       </th>
-                      <th className="px-2 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                      <th className="px-2 py-3 text-left text-xs font-medium tracking-wider text-muted-foreground uppercase">
                         Actions
                       </th>
                     </tr>

--- a/resources/js/pages/Pages/Show.tsx
+++ b/resources/js/pages/Pages/Show.tsx
@@ -1,10 +1,12 @@
 import { PencilIcon, EyeIcon, BookOpenIcon } from '@heroicons/react/24/outline';
 import { Head } from '@inertiajs/react';
+import { ChevronRightIcon, HammerIcon, PlusIcon } from 'lucide-react';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import AppLayout from '@/layouts/app-layout';
+import { formatDate } from '@/utils/commonUtils';
 import { getMarkdownPreview } from '@/utils/markdown';
 
 interface User {
@@ -42,6 +44,7 @@ interface NavigationPage {
   id: string;
   title: string;
   slug: string;
+  published: boolean;
   children?: NavigationPage[];
 }
 
@@ -54,36 +57,36 @@ interface Props {
 }
 
 export default function ShowPage({ mod, page, navigation, canEdit }: Props) {
-  const formatDate = (date: string) => {
-    return new Date(date).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  };
-
   const renderNavigation = (pages: NavigationPage[], level = 0) => {
-    return pages.map((navPage) => (
-      <div key={navPage.id} className={`ml-${level * 4}`}>
-        <a
-          href={`/dashboard/mods/${mod.slug}/pages/${navPage.slug}`}
-          className={`block rounded px-2 py-1 text-sm hover:bg-gray-100 ${
-            navPage.id === page.id
-              ? 'bg-blue-50 font-medium text-blue-700'
-              : 'text-gray-700'
-          }`}
-        >
-          {navPage.title}
-        </a>
-        {navPage.children && navPage.children.length > 0 && (
-          <div className="ml-4">
-            {renderNavigation(navPage.children, level + 1)}
+    return pages
+      .filter((navPage) => navPage.published || canEdit)
+      .map((navPage) => (
+        <div key={navPage.id} className={`ml-${level * 4}`}>
+          <div className="flex items-center gap-2">
+            <a
+              href={`/dashboard/mods/${mod.slug}/pages/${navPage.slug}`}
+              className={`block rounded px-2 py-1 text-sm ${
+                navPage.id === page.id
+                  ? 'font-medium text-primary underline'
+                  : 'text-muted-foreground hover:text-primary'
+              }`}
+            >
+              {navPage.title}
+            </a>
+            {navPage.published === false && (
+              <span className="flex items-center gap-0.5 bg-transparent text-xs text-yellow-400">
+                <HammerIcon className="mr-1 h-3 w-3" />
+                Draft
+              </span>
+            )}
           </div>
-        )}
-      </div>
-    ));
+          {navPage.children && navPage.children.length > 0 && (
+            <div className="ml-4">
+              {renderNavigation(navPage.children, level + 1)}
+            </div>
+          )}
+        </div>
+      ));
   };
 
   return (
@@ -94,7 +97,7 @@ export default function ShowPage({ mod, page, navigation, canEdit }: Props) {
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-4">
           {/* Sidebar Navigation */}
           <div className="lg:col-span-1">
-            <Card>
+            <Card className="border-none bg-transparent">
               <CardHeader>
                 <CardTitle className="text-lg">{mod.name}</CardTitle>
               </CardHeader>
@@ -102,9 +105,15 @@ export default function ShowPage({ mod, page, navigation, canEdit }: Props) {
                 <nav className="space-y-1">{renderNavigation(navigation)}</nav>
 
                 {canEdit && (
-                  <div className="mt-6 border-t pt-4">
-                    <Button size="sm" className="w-full" asChild>
+                  <div className="border-t pt-4">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="w-full"
+                      asChild
+                    >
                       <a href={`/dashboard/mods/${mod.slug}/pages/create`}>
+                        <PlusIcon className="h-4 w-4" />
                         Add New Page
                       </a>
                     </Button>
@@ -117,10 +126,10 @@ export default function ShowPage({ mod, page, navigation, canEdit }: Props) {
           {/* Main Content */}
           <div className="lg:col-span-3">
             {/* Breadcrumbs */}
-            <nav className="mb-6 text-sm text-gray-600">
+            <nav className="mb-6 text-sm text-primary">
               <a
                 href={`/dashboard/mods/${mod.slug}`}
-                className="hover:text-gray-800"
+                className="hover:underline"
               >
                 {mod.name}
               </a>
@@ -128,15 +137,15 @@ export default function ShowPage({ mod, page, navigation, canEdit }: Props) {
                 page.path.length > 0 &&
                 page.path.map((pathItem, index) => (
                   <span key={pathItem.id}>
-                    <span className="mx-2">›</span>
+                    <ChevronRightIcon className="m-1 inline h-4 w-4" />
                     {index === page.path.length - 1 ? (
-                      <span className="font-medium text-gray-900">
+                      <span className="font-medium text-primary">
                         {pathItem.title}
                       </span>
                     ) : (
                       <a
                         href={`/dashboard/mods/${mod.slug}/pages/${pathItem.slug}`}
-                        className="hover:text-gray-800"
+                        className="hover:underline"
                       >
                         {pathItem.title}
                       </a>
@@ -148,10 +157,10 @@ export default function ShowPage({ mod, page, navigation, canEdit }: Props) {
             {/* Page Header */}
             <div className="mb-6 flex items-start justify-between">
               <div>
-                <h1 className="mb-2 text-3xl font-bold text-gray-900">
+                <h1 className="mb-2 text-3xl font-bold text-primary">
                   {page.title}
                 </h1>
-                <div className="flex items-center space-x-4 text-sm text-gray-600">
+                <div className="flex items-center space-x-4 text-sm text-muted-foreground">
                   <span>By {page.creator.name}</span>
                   <span>•</span>
                   <span>Updated {formatDate(page.updated_at)}</span>
@@ -160,7 +169,7 @@ export default function ShowPage({ mod, page, navigation, canEdit }: Props) {
                       <span>•</span>
                       <Badge
                         variant="outline"
-                        className="bg-yellow-50 text-yellow-700"
+                        className="border border-yellow-400 bg-transparent font-bold text-yellow-400"
                       >
                         Draft
                       </Badge>
@@ -170,7 +179,7 @@ export default function ShowPage({ mod, page, navigation, canEdit }: Props) {
               </div>
 
               <div className="flex space-x-3">
-                {mod.visibility === 'public' && (
+                {mod.visibility === 'public' && page.published && (
                   <Button variant="outline" size="sm" asChild>
                     <a href={`/mod/${mod.slug}/${page.slug}`} target="_blank">
                       <EyeIcon className="mr-2 h-4 w-4" />
@@ -215,12 +224,12 @@ export default function ShowPage({ mod, page, navigation, canEdit }: Props) {
                       <a
                         key={child.id}
                         href={`/dashboard/mods/${mod.slug}/pages/${child.slug}`}
-                        className="block rounded-lg border p-4 transition-shadow hover:shadow-md"
+                        className="block rounded-lg border p-4 transition-shadow hover:bg-muted-foreground/5 hover:shadow-md"
                       >
-                        <h3 className="mb-1 font-medium text-gray-900">
+                        <h3 className="mb-1 font-medium text-primary">
                           {child.title}
                         </h3>
-                        <p className="text-sm text-gray-600">
+                        <p className="text-sm text-muted-foreground">
                           {getMarkdownPreview(child.content || '', 150)}
                         </p>
                       </a>
@@ -231,19 +240,21 @@ export default function ShowPage({ mod, page, navigation, canEdit }: Props) {
             )}
 
             {/* Page Footer */}
-            <div className="mt-8 border-t pt-6 text-sm text-gray-600">
-              <div className="flex items-center justify-between">
+            <div className="mt-8 border-t pt-6 text-sm">
+              <div className="flex items-center justify-between text-muted-foreground">
                 <div>
                   Last updated by {page.updater?.name || page.creator.name}
                   on {formatDate(page.updated_at)}
                 </div>
                 {canEdit && (
-                  <a
-                    href={`/dashboard/mods/${mod.slug}/pages/${page.slug}/edit`}
-                    className="text-blue-600 hover:text-blue-800"
-                  >
-                    Improve this page
-                  </a>
+                  <Button size="sm" variant="outline" asChild>
+                    <a
+                      href={`/dashboard/mods/${mod.slug}/pages/${page.slug}/edit`}
+                    >
+                      <PencilIcon className="mr-2 h-4 w-4" />
+                      Improve this Page
+                    </a>
+                  </Button>
                 )}
               </div>
             </div>

--- a/resources/js/pages/Public/Mod.tsx
+++ b/resources/js/pages/Public/Mod.tsx
@@ -76,7 +76,11 @@ export default function PublicMod({ mod }: Props) {
   };
 
   return (
-    <PublicLayout modName={mod.name} modSlug={mod.slug} modIconUrl={mod.icon_url}>
+    <PublicLayout
+      modName={mod.name}
+      modSlug={mod.slug}
+      modIconUrl={mod.icon_url}
+    >
       <Head title={`${mod.name} Documentation`} />
 
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-4">

--- a/resources/js/pages/Public/Page.tsx
+++ b/resources/js/pages/Public/Page.tsx
@@ -191,17 +191,22 @@ export default function PublicPage({ mod, page, navigation }: Props) {
               <div className="grid grid-cols-2 gap-6">
                 <div className="flex justify-start">
                   {prevPage && (
-                    <Button variant="outline" size="lg" asChild className="group h-auto p-4 transition-all hover:shadow-md">
+                    <Button
+                      variant="outline"
+                      size="lg"
+                      asChild
+                      className="group h-auto p-4 transition-all hover:shadow-md"
+                    >
                       <a
                         href={`/mod/${mod.slug}/${prevPage.slug}`}
                         className="flex items-center space-x-3"
                       >
                         <ChevronLeftIcon className="h-5 w-5 shrink-0 text-muted-foreground group-hover:text-foreground" />
                         <div className="text-left">
-                          <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                          <div className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
                             Previous
                           </div>
-                          <div className="font-semibold text-foreground group-hover:text-primary line-clamp-2">
+                          <div className="line-clamp-2 font-semibold text-foreground group-hover:text-primary">
                             {prevPage.title}
                           </div>
                         </div>
@@ -212,16 +217,21 @@ export default function PublicPage({ mod, page, navigation }: Props) {
 
                 <div className="flex justify-end">
                   {nextPage && (
-                    <Button variant="outline" size="lg" asChild className="group h-auto p-4 transition-all hover:shadow-md">
+                    <Button
+                      variant="outline"
+                      size="lg"
+                      asChild
+                      className="group h-auto p-4 transition-all hover:shadow-md"
+                    >
                       <a
                         href={`/mod/${mod.slug}/${nextPage.slug}`}
                         className="flex items-center space-x-3"
                       >
                         <div className="text-right">
-                          <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                          <div className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
                             Next
                           </div>
-                          <div className="font-semibold text-foreground group-hover:text-primary line-clamp-2">
+                          <div className="line-clamp-2 font-semibold text-foreground group-hover:text-primary">
                             {nextPage.title}
                           </div>
                         </div>


### PR DESCRIPTION
# Description
This PR redesigns and refactors all routes for displaying and editing documentation pages. It improves UI, Markdown Editor with optional visibility options for the editor Views and improves overall Readability and unifies designs

# Preview
<img width="1348" height="901" alt="image" src="https://github.com/user-attachments/assets/33c3174c-6cb2-481a-86b8-65a18cdaec2e" />


<img width="1373" height="958" alt="image" src="https://github.com/user-attachments/assets/1b5a5f9e-3bd5-43c8-a177-619b0263d660" />
> Markdown Editor


<img width="1372" height="892" alt="image" src="https://github.com/user-attachments/assets/b6d7288a-e4e9-49ea-9f97-9d630c570c5f" />
> Split View

<img width="1332" height="844" alt="image" src="https://github.com/user-attachments/assets/de5a7672-883a-4260-83d1-3b0a9fabf149" />
> Full Preview

<img width="1199" height="522" alt="image" src="https://github.com/user-attachments/assets/f464155d-88a8-4410-bf0a-77eecc25f5d4" />


Closes #33
Closes #34