### PR TITLE
GH-63: add anchor links to the markdown renderer

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -92,10 +92,23 @@
   text-decoration: none;
   border: none;
   background: none;
+  flex-shrink: 0;
+  margin-left: 0.375rem;
+  color: var(--color-muted-foreground);
+  opacity: 0;
+  transition: opacity 0.15s ease;
 }
 
 .prose .heading-anchor:hover {
   text-decoration: none;
+  color: var(--color-foreground);
+}
+
+.prose .heading-with-link:hover .heading-anchor,
+.prose .heading-with-link:hover .copy-heading-btn,
+.prose .heading-with-link:focus-within .heading-anchor,
+.prose .heading-with-link:focus-within .copy-heading-btn {
+  opacity: 1;
 }
 
 .prose .copy-heading-btn {
@@ -104,14 +117,18 @@
   justify-content: center;
   width: 1.5rem;
   height: 1.5rem;
+  flex-shrink: 0;
   border: none;
   background: none;
   cursor: pointer;
+  color: var(--color-muted-foreground);
+  opacity: 0;
   transition: all 0.2s ease-in-out;
 }
 
 .prose .copy-heading-btn:hover {
   transform: scale(1.1);
+  color: var(--color-foreground);
 }
 
 .prose .copy-heading-btn:focus {

--- a/resources/js/components/MarkdownRenderer.tsx
+++ b/resources/js/components/MarkdownRenderer.tsx
@@ -1,10 +1,12 @@
 import DOMPurify from 'dompurify';
 import hljs from 'highlight.js';
+import { CheckIcon, ClipboardIcon, LinkIcon } from 'lucide-react';
 import { marked } from 'marked';
 import markedFootnote from 'marked-footnote';
 import { gfmHeadingId } from 'marked-gfm-heading-id';
 import 'highlight.js/styles/github-dark.css';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 interface MarkdownRendererProps {
   content: string | null | undefined;
@@ -31,24 +33,86 @@ marked.setOptions({
   breaks: true,
 });
 
+const CLIPBOARD_ICON_SVG = renderToStaticMarkup(<LinkIcon size={16} aria-hidden="true" />);
+const CHECK_ICON_SVG = renderToStaticMarkup(<CheckIcon size={16} aria-hidden="true" />);
+
+function addHeadingAnchors(html: string): string {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+
+  doc.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((heading) => {
+    const id = heading.id;
+    if (!id) return;
+
+    heading.classList.add('heading-with-link');
+
+    // Wrap existing inline content in a span so flex layout works correctly
+    const contentSpan = doc.createElement('span');
+    while (heading.firstChild) {
+      contentSpan.appendChild(heading.firstChild);
+    }
+    heading.appendChild(contentSpan);
+
+    const headingText = contentSpan.textContent ?? '';
+
+    const copyBtn = doc.createElement('button');
+    copyBtn.type = 'button';
+    copyBtn.className = 'copy-heading-btn';
+    copyBtn.setAttribute('data-heading-id', id);
+    copyBtn.setAttribute('aria-label', `Copy link to "${headingText}"`);
+    copyBtn.innerHTML = CLIPBOARD_ICON_SVG;
+    heading.appendChild(copyBtn);
+  });
+
+  return doc.body.innerHTML;
+}
+
 export default function MarkdownRenderer({
   content,
   className = '',
 }: MarkdownRendererProps) {
   const [htmlContent, setHtmlContent] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
   const safeContent = content ?? '';
 
   useEffect(() => {
     const parseContent = async () => {
       const html = await marked.parse(safeContent);
-      setHtmlContent(DOMPurify.sanitize(html));
+      const sanitized = DOMPurify.sanitize(html);
+      setHtmlContent(addHeadingAnchors(sanitized));
     };
 
     parseContent();
   }, [safeContent]);
 
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleClick = (e: MouseEvent) => {
+      const btn = (e.target as Element).closest('.copy-heading-btn') as HTMLElement | null;
+      if (!btn) return;
+
+      const headingId = btn.getAttribute('data-heading-id');
+      if (!headingId) return;
+
+      const url = `${window.location.origin}${window.location.pathname}#${headingId}`;
+      navigator.clipboard.writeText(url).then(() => {
+        const original = btn.innerHTML;
+        btn.innerHTML = CHECK_ICON_SVG;
+        setTimeout(() => {
+          btn.innerHTML = original;
+        }, 1500);
+      });
+    };
+
+    container.addEventListener('click', handleClick);
+    return () => container.removeEventListener('click', handleClick);
+  }, [htmlContent]);
+
   return (
     <div
+      ref={containerRef}
       className={`prose max-w-none prose-slate dark:prose-invert ${className}`}
       dangerouslySetInnerHTML={{ __html: htmlContent }}
     />


### PR DESCRIPTION
# Description

Add Anchor links to the markdown renderer in order to allow copying links to specific chapters inside documentation. It currently focuses on all heading elements (h1 - h6). It instantly copies the link to clipboard

# Example:
![anchor-links](https://github.com/user-attachments/assets/e2788721-3b60-48d0-b6c2-3655da192c7e)

<img width="1353" height="954" alt="image" src="https://github.com/user-attachments/assets/b887fe23-ad06-4197-80ce-e5de616b976d" />
<img width="1111" height="652" alt="image" src="https://github.com/user-attachments/assets/41bde38c-91dd-467b-b916-026987e4fdc8" />

 gh-63
