### PR TITLE
Remove extra padding from mods navbar

### DIFF
--- a/resources/js/components/SeoMeta.tsx
+++ b/resources/js/components/SeoMeta.tsx
@@ -48,17 +48,35 @@ export default function SeoMeta({
 
   return (
     <Head title={title}>
-      <meta head-key="meta-description" name="description" content={resolvedDescription} />
+      <meta
+        head-key="meta-description"
+        name="description"
+        content={resolvedDescription}
+      />
       {resolvedUrl && (
         <link head-key="meta-canonical" rel="canonical" href={resolvedUrl} />
       )}
-      <meta head-key="meta-robots" name="robots" content={noIndex ? 'noindex, nofollow' : 'index, follow'} />
+      <meta
+        head-key="meta-robots"
+        name="robots"
+        content={noIndex ? 'noindex, nofollow' : 'index, follow'}
+      />
 
       <meta head-key="og-type" property="og:type" content={type} />
-      <meta head-key="og-site-name" property="og:site_name" content={siteName} />
+      <meta
+        head-key="og-site-name"
+        property="og:site_name"
+        content={siteName}
+      />
       <meta head-key="og-title" property="og:title" content={ogTitle} />
-      <meta head-key="og-description" property="og:description" content={resolvedDescription} />
-      {resolvedUrl && <meta head-key="og-url" property="og:url" content={resolvedUrl} />}
+      <meta
+        head-key="og-description"
+        property="og:description"
+        content={resolvedDescription}
+      />
+      {resolvedUrl && (
+        <meta head-key="og-url" property="og:url" content={resolvedUrl} />
+      )}
       {resolvedImage && (
         <meta head-key="og-image" property="og:image" content={resolvedImage} />
       )}
@@ -75,9 +93,12 @@ export default function SeoMeta({
         content={resolvedDescription}
       />
       {resolvedImage && (
-        <meta head-key="twitter-image" name="twitter:image" content={resolvedImage} />
+        <meta
+          head-key="twitter-image"
+          name="twitter:image"
+          content={resolvedImage}
+        />
       )}
     </Head>
   );
 }
-

--- a/resources/js/pages/Public/Mod.tsx
+++ b/resources/js/pages/Public/Mod.tsx
@@ -140,7 +140,7 @@ export default function PublicMod({ mod }: Props) {
             </Card>
 
             {/* Navigation Card */}
-            <Card className="overflow-hidden gap-0 rounded-2xl border-border/70 bg-card/90 shadow-sm backdrop-blur-sm">
+            <Card className="gap-0 overflow-hidden rounded-2xl border-border/70 bg-card/90 shadow-sm backdrop-blur-sm">
               <CardHeader className="border-b border-border/60 pb-3">
                 <CardTitle className="text-sm font-semibold tracking-wide uppercase">
                   Documentation
@@ -155,9 +155,7 @@ export default function PublicMod({ mod }: Props) {
                     </p>
                   </div>
                 ) : (
-                  <nav>
-                    {renderPageTree(mod.root_pages)}
-                  </nav>
+                  <nav>{renderPageTree(mod.root_pages)}</nav>
                 )}
               </CardContent>
             </Card>

--- a/resources/js/pages/Public/Page.tsx
+++ b/resources/js/pages/Public/Page.tsx
@@ -65,10 +65,7 @@ export default function PublicPage({ mod, page, navigation }: Props) {
 
   const renderNavigation = (pages: NavigationPage[], level = 0) => {
     return pages.map((navPage) => (
-      <div
-        key={navPage.id}
-        style={{ marginLeft: level === 0 ? 0 : level * 2 }}
-      >
+      <div key={navPage.id} style={{ marginLeft: level === 0 ? 0 : level * 2 }}>
         {navPage.kind === 'category' ? (
           <div className="flex items-center gap-2 rounded-lg border border-transparent px-3 py-2 text-sm text-muted-foreground/90">
             <BookOpenIcon className="h-4 w-4 shrink-0" />
@@ -170,7 +167,7 @@ export default function PublicPage({ mod, page, navigation }: Props) {
             </Card>
 
             {/* Navigation */}
-            <Card className="overflow-hidden gap-0 rounded-2xl border-border/70 bg-card/90 shadow-sm backdrop-blur-sm">
+            <Card className="gap-0 overflow-hidden rounded-2xl border-border/70 bg-card/90 shadow-sm backdrop-blur-sm">
               <CardHeader className="border-b border-border/60 pb-3">
                 <CardTitle className="text-sm font-semibold tracking-wide uppercase">
                   Contents
@@ -185,9 +182,7 @@ export default function PublicPage({ mod, page, navigation }: Props) {
                     </p>
                   </div>
                 ) : (
-                  <nav>
-                    {renderNavigation(navigation)}
-                  </nav>
+                  <nav>{renderNavigation(navigation)}</nav>
                 )}
               </CardContent>
             </Card>


### PR DESCRIPTION
I also reduced the nested indentation to allow for more space for deeply-nested pages. The contents inside the navbar are optically centered.

Here is a before and after.

<img width="627" height="828" alt="image" src="https://github.com/user-attachments/assets/d18bf69d-75ce-4ec6-aeb2-01f25e407f46" />