### PR TITLE
GH-80: Ensure correct ref is used in checkout step of lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
The default `actions/checkout` behavior on `pull_request` events is to check out a merge commit combining the PR branch with the target branch. GitHub does this by default so that CI validates the result of merging, catching integration issues early. This causes two issues:

-  Unrelated failures: If main has lint issues, all PRs fail even if they don't touch the affected files
- Blocked by merge conflicts: When a PR has merge conflicts, GitHub can't create the merge commit, so the workflow doesn't run at all

I've updated the `quality` workflow to check out the PR head commit (`github.event.pull_request.head.sha`) instead of the default merge commit. It falls back to `github.sha` for push events so direct pushes to main should be unaffected. 

The `tests` workflow intentionally keeps the merge commit behavior. I believe that tests should validate that the PR integrates correctly with `main`, so catching merge-related issues there is desirable. Lint checks, on the other hand, should only care about the code style of the changes being proposed. Let me know what you think. gh-80
