### PR TITLE
GH-84 fix: add more css vars for markdown

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -23,19 +23,59 @@
 }
 
 :root {
+  --markdown-text-fg: var(--color-foreground);
+  --markdown-muted-fg: var(--color-muted-foreground);
+
+  --markdown-link-color: var(--color-primary);
+  --markdown-link-hover-color: var(--color-accent-foreground);
+
+  --markdown-list-marker: var(--color-muted-foreground);
+
   --markdown-code-block-bg: var(--color-muted);
   --markdown-code-block-fg: var(--color-primary);
+  
   --markdown-inline-code-bg: color-mix(
     in oklab,
     var(--color-muted-foreground) 20%,
     transparent
   );
   --markdown-inline-code-fg: var(--color-primary);
+
   --markdown-callout-note-border: var(--chart-2);
   --markdown-callout-tip-border: var(--chart-3);
   --markdown-callout-important-border: var(--chart-4);
   --markdown-callout-warning-border: var(--chart-1);
   --markdown-callout-caution-border: var(--destructive);
+
+  --markdown-blockquote-border: var(--color-border);
+  --markdown-blockquote-fg: var(--color-muted-foreground);
+
+  --markdown-hr-color: var(--color-border);
+
+   --markdown-table-border: var(--color-border);
+  --markdown-table-header-border: var(--color-accent);
+}
+
+.prose :where(p):not(blockquote p),
+.prose li,
+.prose strong,
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4,
+.prose h5,
+.prose h6 {
+  color: var(--markdown-text-fg);
+}
+
+.prose em,
+.prose del {
+  color: var(--markdown-muted-fg);
+}
+
+.prose strong em,
+.prose em strong {
+  color: var(--markdown-text-fg); 
 }
 
 .prose pre.hljs-code-block {
@@ -82,6 +122,36 @@
   border-radius: 0.5rem;
   padding: 1rem 1.25rem;
 }
+
+.prose blockquote {
+  border-left-color: var(--markdown-blockquote-border);
+  color: var(--markdown-blockquote-fg);
+}
+
+.prose hr {
+  border-color: var(--markdown-hr-color);
+}
+
+.prose a {
+  color: var(--markdown-link-color);
+}
+.prose a:hover {
+  color: var(--color-accent-foreground);
+}
+
+.prose ul > li::marker,
+.prose ol > li::marker {
+  color: var(--markdown-list-marker);
+}
+
+.prose table tr {
+  border-bottom-color: var(--markdown-table-border);
+}
+
+.prose table thead {
+  border-bottom-color: var(--markdown-table-header-border);
+}
+
 .prose .heading-container {
   position: relative;
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -33,7 +33,7 @@
 
   --markdown-code-block-bg: var(--color-muted);
   --markdown-code-block-fg: var(--color-primary);
-  
+
   --markdown-inline-code-bg: color-mix(
     in oklab,
     var(--color-muted-foreground) 20%,
@@ -52,7 +52,7 @@
 
   --markdown-hr-color: var(--color-border);
 
-   --markdown-table-border: var(--color-border);
+  --markdown-table-border: var(--color-border);
   --markdown-table-header-border: var(--color-accent);
 }
 
@@ -75,7 +75,7 @@
 
 .prose strong em,
 .prose em strong {
-  color: var(--markdown-text-fg); 
+  color: var(--markdown-text-fg);
 }
 
 .prose pre.hljs-code-block {

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -31,10 +31,10 @@ import { UserMenuContent } from '@/components/user-menu-content';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import { useInitials } from '@/hooks/use-initials';
 import { cn, toUrl } from '@/lib/utils';
-import { dashboard } from '@/routes';
 import type { BreadcrumbItem, NavItem, SharedData } from '@/types';
 import AppLogo from './app-logo';
 import AppLogoIcon from './app-logo-icon';
+import { dashboard } from '@/routes';
 
 type Props = {
   breadcrumbs?: BreadcrumbItem[];

--- a/resources/js/components/app-navbar.tsx
+++ b/resources/js/components/app-navbar.tsx
@@ -17,11 +17,11 @@ import {
 } from '@/components/ui/sheet';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import { cn } from '@/lib/utils';
-import { dashboard, login, register } from '@/routes';
 import type { SharedData } from '@/types';
 import { mainNavItems } from '@/utils/commonUtils';
 import HytaleModdingLogo from './hytale-modding-logo';
 import { UserMenuContent } from './user-menu-content';
+import { dashboard, login, register } from '@/routes';
 
 interface AppNavbarProps {
   brandHref?: string;

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -12,10 +12,10 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@/components/ui/sidebar';
-import { dashboard } from '@/routes';
 import type { NavItem } from '@/types';
 import { mainNavItems } from '@/utils/commonUtils';
 import AppLogo from './app-logo';
+import { dashboard } from '@/routes';
 
 const footerNavItems: NavItem[] = [
   {

--- a/resources/js/components/delete-user.tsx
+++ b/resources/js/components/delete-user.tsx
@@ -1,6 +1,5 @@
 import { Form } from '@inertiajs/react';
 import { useRef } from 'react';
-import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileController';
 import Heading from '@/components/heading';
 import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
@@ -15,6 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileController';
 
 export default function DeleteUser() {
   const passwordInput = useRef<HTMLInputElement>(null);

--- a/resources/js/components/two-factor-recovery-codes.tsx
+++ b/resources/js/components/two-factor-recovery-codes.tsx
@@ -9,8 +9,8 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { regenerateRecoveryCodes } from '@/routes/two-factor';
 import AlertError from './alert-error';
+import { regenerateRecoveryCodes } from '@/routes/two-factor';
 
 type Props = {
   recoveryCodesList: string[];

--- a/resources/js/components/two-factor-setup-modal.tsx
+++ b/resources/js/components/two-factor-setup-modal.tsx
@@ -19,9 +19,9 @@ import {
 import { useAppearance } from '@/hooks/use-appearance';
 import { useClipboard } from '@/hooks/use-clipboard';
 import { OTP_MAX_LENGTH } from '@/hooks/use-two-factor-auth';
-import { confirm } from '@/routes/two-factor';
 import AlertError from './alert-error';
 import { Spinner } from './ui/spinner';
+import { confirm } from '@/routes/two-factor';
 
 function GridScanIcon() {
   return (

--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -10,9 +10,9 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useInitials } from '@/hooks/use-initials';
+import type { SharedData } from '@/types';
 import { dashboard } from '@/routes';
 import { index as modsIndex } from '@/routes/mods';
-import type { SharedData } from '@/types';
 
 export function UserMenuContent() {
   const { auth } = usePage<SharedData>().props;

--- a/resources/js/hooks/use-two-factor-auth.ts
+++ b/resources/js/hooks/use-two-factor-auth.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
-import { qrCode, recoveryCodes, secretKey } from '@/routes/two-factor';
 import type { TwoFactorSecretKey, TwoFactorSetupData } from '@/types';
+import { qrCode, recoveryCodes, secretKey } from '@/routes/two-factor';
 
 export type UseTwoFactorAuthReturn = {
   qrCodeSvg: string | null;

--- a/resources/js/layouts/auth/auth-simple-layout.tsx
+++ b/resources/js/layouts/auth/auth-simple-layout.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@inertiajs/react';
 import HytaleModdingLogo from '@/components/hytale-modding-logo';
-import { home } from '@/routes';
 import type { AuthLayoutProps } from '@/types';
+import { home } from '@/routes';
 
 export default function AuthSimpleLayout({
   children,

--- a/resources/js/layouts/auth/auth-split-layout.tsx
+++ b/resources/js/layouts/auth/auth-split-layout.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@inertiajs/react';
 import HytaleModdingLogo from '@/components/hytale-modding-logo';
-import { home } from '@/routes';
 import type { AuthLayoutProps } from '@/types';
+import { home } from '@/routes';
 
 export default function AuthSplitLayout({
   children,

--- a/resources/js/layouts/settings/layout.tsx
+++ b/resources/js/layouts/settings/layout.tsx
@@ -5,11 +5,11 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import { cn, toUrl } from '@/lib/utils';
+import type { NavItem } from '@/types';
 import { edit as editAppearance } from '@/routes/appearance';
 import { edit } from '@/routes/profile';
 import { show } from '@/routes/two-factor';
 import { edit as editPassword } from '@/routes/user-password';
-import type { NavItem } from '@/types';
 
 const sidebarNavItems: NavItem[] = [
   {

--- a/resources/js/pages/settings/appearance.tsx
+++ b/resources/js/pages/settings/appearance.tsx
@@ -3,8 +3,8 @@ import AppearanceTabs from '@/components/appearance-tabs';
 import Heading from '@/components/heading';
 import AppLayout from '@/layouts/app-layout';
 import SettingsLayout from '@/layouts/settings/layout';
-import { edit as editAppearance } from '@/routes/appearance';
 import type { BreadcrumbItem } from '@/types';
+import { edit as editAppearance } from '@/routes/appearance';
 
 const breadcrumbs: BreadcrumbItem[] = [
   {

--- a/resources/js/pages/settings/password.tsx
+++ b/resources/js/pages/settings/password.tsx
@@ -1,7 +1,6 @@
 import { Transition } from '@headlessui/react';
 import { Form, Head } from '@inertiajs/react';
 import { useRef } from 'react';
-import PasswordController from '@/actions/App/Http/Controllers/Settings/PasswordController';
 import Heading from '@/components/heading';
 import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
@@ -9,8 +8,9 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AppLayout from '@/layouts/app-layout';
 import SettingsLayout from '@/layouts/settings/layout';
-import { edit } from '@/routes/user-password';
 import type { BreadcrumbItem } from '@/types';
+import PasswordController from '@/actions/App/Http/Controllers/Settings/PasswordController';
+import { edit } from '@/routes/user-password';
 
 const breadcrumbs: BreadcrumbItem[] = [
   {

--- a/resources/js/pages/settings/profile.tsx
+++ b/resources/js/pages/settings/profile.tsx
@@ -2,7 +2,6 @@ import { Transition } from '@headlessui/react';
 import { Form, Head, Link, usePage, router } from '@inertiajs/react';
 import { Camera, Trash2 } from 'lucide-react';
 import { useRef, useState } from 'react';
-import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileController';
 import DeleteUser from '@/components/delete-user';
 import Heading from '@/components/heading';
 import InputError from '@/components/input-error';
@@ -11,9 +10,10 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AppLayout from '@/layouts/app-layout';
 import SettingsLayout from '@/layouts/settings/layout';
+import type { BreadcrumbItem, SharedData } from '@/types';
+import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileController';
 import { edit } from '@/routes/profile';
 import { send } from '@/routes/verification';
-import type { BreadcrumbItem, SharedData } from '@/types';
 
 const breadcrumbs: BreadcrumbItem[] = [
   {

--- a/resources/js/pages/settings/two-factor.tsx
+++ b/resources/js/pages/settings/two-factor.tsx
@@ -9,8 +9,8 @@ import { Button } from '@/components/ui/button';
 import { useTwoFactorAuth } from '@/hooks/use-two-factor-auth';
 import AppLayout from '@/layouts/app-layout';
 import SettingsLayout from '@/layouts/settings/layout';
-import { disable, enable, show } from '@/routes/two-factor';
 import type { BreadcrumbItem } from '@/types';
+import { disable, enable, show } from '@/routes/two-factor';
 
 type Props = {
   requiresConfirmation?: boolean;

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -11,10 +11,10 @@ import HytaleModdingLogo from '@/components/hytale-modding-logo';
 import SeoMeta from '@/components/SeoMeta';
 import { Button } from '@/components/ui/button';
 import { UserMenuContent } from '@/components/user-menu-content';
+import type { SharedData } from '@/types';
 import { dashboard, home, login, register } from '@/routes';
 import mods from '@/routes/mods';
 import publicRoutes from '@/routes/public';
-import type { SharedData } from '@/types';
 
 const workflowSteps: Array<{
   title: string;

--- a/resources/js/utils/commonUtils.tsx
+++ b/resources/js/utils/commonUtils.tsx
@@ -1,6 +1,6 @@
 import { LayoutGrid } from 'lucide-react';
-import { dashboard } from '@/routes';
 import type { NavItem } from '@/types/navigation';
+import { dashboard } from '@/routes';
 
 export const mainNavItems: NavItem[] = [
   {


### PR DESCRIPTION
I know the issue is already closed, but with the PR that Neil made, the variables only got hardcoded code blocks, inline code, and callouts. The others that had `--tw` variables were not changed. 

For example, [page](https://wiki.hytalemodding.dev/mod/css-var-test) without custom colors, just the site palette.

gh-84